### PR TITLE
Stalebot

### DIFF
--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-stale: -1
+          days-before-stale: 365
           days-before-close: 0
-          #Close immediately after stale.
+          #Close immediately after stale, 365 days.
           ignore-updates: true
           remove-stale-when-updated: false
           #Prevent bumping issues to avoid closing.

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-stale: 1
+          days-before-stale: 0
           days-before-close: 0
           #Close immediately after stale.
           ignore-updates: true

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -1,0 +1,22 @@
+# Full documentation at https://github.com/marketplace/actions/close-stale-issues
+
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+permissions:
+  issues: write
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 1
+          days-before-close: 0
+          #Close immediately after stale.
+          ignore-updates: true
+          remove-stale-when-updated: false
+          #Prevent bumping issues to avoid closing.
+          debug-only: true
+          #Dry-run: You can run this action in debug only mode (no actions will be taken on your issues and pull requests) by passing debug-only to true as an argument to the action.

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -19,5 +19,5 @@ jobs:
           ignore-updates: true
           remove-stale-when-updated: false
           #Prevent bumping issues to avoid closing.
-          debug-only: true
+          debug-only: false
           #Dry-run: You can run this action in debug only mode (no actions will be taken on your issues and pull requests) by passing debug-only to true as an argument to the action.

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -2,6 +2,7 @@
 
 name: 'Close stale issues and PRs'
 on:
+  workflow_dispatch:
   schedule:
     - cron: '30 1 * * *'
 permissions:

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-stale: 0
+          days-before-stale: -1
           days-before-close: 0
           #Close immediately after stale.
           ignore-updates: true


### PR DESCRIPTION
Per https://www.construct.net/en/forum/construct-3/general-discussion-7/upcoming-feature-requests-184629#forumPost1116815, configured stalebot to close issues after 365 days, regardless of activity.


Tested a manual run with the following, resulting in https://github.com/oosyrag/Construct-feature-requests/issues/1 being closed by the bot.
```
          days-before-stale: 0
          days-before-close: 0
```
I also tried with `days-before-stale: -1` to see if it was able to skip the stale labelling completely, but it didn't work as it seems closing the issue requires it to be stale first.


A consideration to take with this approach is that the user will probably by default receive an e-mail notification when the issues is closed, which might encourage re-submittal of issues. I'm not sure if an e-mail is sent when manually closing someone else's issue - I did not receive one for closing my own issue as completed. There is no e-mail notification from marking the issue as stale, only for closing as not planned.


Documentation at: https://github.com/marketplace/actions/close-stale-issues
`ignore-updates: true` prevents bumping an issue to keep it from being closed.
`remove-stale-when-updated: false` is included as well but should be irrelevant with ignore updates true and issues being closed immediately after being marked stale in the same workflow.
 `stale-issue-message:` and `close-issue-message:` can be used to add messages/comments if desired.
